### PR TITLE
武器の統計表示を追加

### DIFF
--- a/Infinity/HUDs/BattleResult/BattleResultHudController.cs
+++ b/Infinity/HUDs/BattleResult/BattleResultHudController.cs
@@ -72,7 +72,7 @@ internal partial class BattleResultHudController : Node
                         {
                             var label = new Label();
                             label.HorizontalAlignment = HorizontalAlignment.Center;
-                            label.Text = $"{weapon.MinionId}: total {damage} damage";
+                            label.Text = $"{weapon.MinionId}: total {damage:0} damage";
                             vbox.AddChild(label);
                         }
                     }

--- a/Infinity/Weapons/ClawGen.cs
+++ b/Infinity/Weapons/ClawGen.cs
@@ -56,8 +56,6 @@ public partial class ClawGen : WeaponBase
 
         var newCoolDown = 60u - _enemyHitStacks * 10u;
         BaseCoolDownFrame = newCoolDown;
-
-        GD.Print(BaseCoolDownFrame);
     }
 
     private protected override void SpawnProjectile(uint level)


### PR DESCRIPTION
- Main のバトルリザルト画面で武器のトータルダメージ (毎ウェーブリセット) を表示するようにしました
- Main に直プッシュしてしまったので Diff 終わっています