### PR TITLE
ホーネットのステータス調整

### DIFF
--- a/Infinity/Enemy/(Enemy) Hornet.tscn
+++ b/Infinity/Enemy/(Enemy) Hornet.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://ctsnxp14rpk1l"]
+[gd_scene load_steps=10 format=3 uid="uid://ctsnxp14rpk1l"]
 
 [ext_resource type="Script" path="res://Infinity/Enemy/Hornet.cs" id="1_s0dvv"]
 [ext_resource type="PackedScene" uid="uid://cntnfk7uhqmi2" path="res://Infinity/Projectiles/(Projectile) SparkBoltDark.tscn" id="2_gjpaw"]
@@ -6,6 +6,9 @@
 [ext_resource type="PackedScene" uid="uid://celvufqqj3boe" path="res://Infinity/VFX/BloodSplat.tscn" id="3_t7ik7"]
 [ext_resource type="Texture2D" uid="uid://dxm3tr4es72kd" path="res://Infinity/Enemy/hornet.png" id="4_pyg4b"]
 [ext_resource type="Texture2D" uid="uid://cxvitewt46k05" path="res://Common/Resources/Textures/white_4x4_srgb.png" id="5_dq6qi"]
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_xiomk"]
+friction = 0.1
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_guyc4"]
 resource_local_to_scene = true
@@ -15,17 +18,20 @@ shader_parameter/offset = Vector2(30, 30)
 shader_parameter/modulate = Color(0, 0, 1, 1)
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_4ld33"]
-radius = 13.0384
+radius = 6.0
 
 [node name="Hornet" type="RigidBody2D"]
 collision_layer = 4
 collision_mask = 4
+physics_material_override = SubResource("PhysicsMaterial_xiomk")
 gravity_scale = 0.0
 lock_rotation = true
 script = ExtResource("1_s0dvv")
+_minAttackDistance = 100
+_maxAttackDistance = 200
 _projectile = ExtResource("2_gjpaw")
-_defaultMoveSpeed = 60.0
-_defaultHealth = 200.0
+_defaultMoveSpeed = 80.0
+_defaultHealth = 80.0
 _onDeadParticle = ExtResource("3_t7ik7")
 
 [node name="Sprite" type="Sprite2D" parent="."]

--- a/Infinity/Enemy/Hornet.cs
+++ b/Infinity/Enemy/Hornet.cs
@@ -132,7 +132,7 @@ public partial class Hornet : EnemyBase
         {
             // ToDo: 仮実装
             // プレイヤー / 敵(味方) / 壁 に当たるようにする
-            prj.CollisionMask = Constant.LAYER_PLAYER | Constant.LAYER_MOB | Constant.LAYER_WALL;
+            prj.CollisionMask = Constant.LAYER_PLAYER | Constant.LAYER_WALL;
             prj.Damage = _power;
             prj.Speed = 180;
             prj.LifeFrame = 300;


### PR DESCRIPTION
フレンドリファイア切った
攻撃範囲を狭く
移動速度を速く
当たり判定を小さく、摩擦を大きく